### PR TITLE
enhanced configuration of rollup

### DIFF
--- a/js/rollup.config.js
+++ b/js/rollup.config.js
@@ -2,6 +2,7 @@ import nodeResolve  from '@rollup/plugin-node-resolve'
 import commonjs     from '@rollup/plugin-commonjs'
 import babel        from '@rollup/plugin-babel'
 import css from "rollup-plugin-import-css"
+import json from '@rollup/plugin-json';
 
 export default {
   input: "js/index.js",
@@ -14,7 +15,7 @@ export default {
     }
   ],
   plugins: [
-    nodeResolve(),
+    nodeResolve({ preferBuiltins: true, mainFields: ['browser'] }),
     commonjs(), 
     babel({
       include: [ "./js/**" ],
@@ -22,7 +23,8 @@ export default {
       babelHelpers: "bundled",
     }),
     css({
-      output: 'docs/css/bundle.css'
-    }) 
+      output: 'bundle.css'
+    }),
+    json()
   ]
 }


### PR DESCRIPTION
@hfu I enhanced the configuration of rollup. In previous setting, when I imported css in index.js, `bundle.css` was generated under `docs/jsdocs/js` folder. I fixed this bug. Also, added additional plugin for rollup.