### PR TITLE
fix `rake inet:sprite` and `rake style`

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -46,7 +46,7 @@ namespace :inet do
     u = "https://github.com/mapbox/maki/zipball/main"
     dest = "./src/maki"
     if !File.exist?("#{dest}.zip")
-      sh "wget -O #{dest} #{u}"
+      sh "wget -O #{dest}.zip #{u}"
     end
     sh "node sprite.js"
   end

--- a/Rakefile
+++ b/Rakefile
@@ -43,10 +43,10 @@ namespace :inet do
   
   desc 'clone and build maki, and copy to docs'
   task :sprite do
-    u = "https://github.com/mapbox/maki/zipball/master"
+    u = "https://github.com/mapbox/maki/zipball/main"
     dest = "./src/maki"
     if !File.exist?("#{dest}.zip")
-      sh "wget -O #{dest}.zip #{u}"
+      sh "wget -O #{dest} #{u}"
     end
     sh "node sprite.js"
   end
@@ -67,7 +67,6 @@ task :style do
   style = JSON.parse(File.read('docs/style.json'))
   style['center'] = center
   File.write('docs/style.json', JSON.pretty_generate(style))
-  sh "gl-style-validate docs/style.json"
 end
 
 desc 'host the site'

--- a/sprite.js
+++ b/sprite.js
@@ -36,7 +36,7 @@ class Spriter{
     let svgs = []
     for (let i = 0; i < this.table.length / 2; i++) {
       const id = this.table[2 * i]
-      const svgName = `${this.table[2 * i + 1]}-11.svg`
+      const svgName = `${this.table[2 * i + 1]}.svg`
       const svgData = icons[svgName]
       if (!svgData){
         throw new Error(`Invalid icon name: ${id}`)


### PR DESCRIPTION
Hi.

Thanks to this project, I was able to build my first vector tiles!
But I ran into some trouble in the build process.
I've try to fix it and I want to give some feedback through this pull request.


## What I do

I found two issues and try to fix it.

- `rake inet:sprite` does not working correctly.
  - Because
    - Base branch of the repository https://github.com/mapbox/maki/ has changed name from `master` to `main`.
    - Also https://github.com/mapbox/maki/ has changed sprite file names whithout `-11`.
  - I've fix this issue.
- `rake style` will always aborted.
  - Because
    - The command `gl-style-validate` in `@mapbox/mapbox-gl-style-spec` has broken.
      - Issue: https://github.com/mapbox/mapbox-gl-js/issues/10965
  - I've remove `gl-style-validate` command from Rakefile.


## What I've checked

Run

```bash
cp .env.sample .env
docker compose build
docker compose up
```

and checked

- No error messages.
- http://localhost:9966/ is working expectedly.

## Preventive measures

- We may use specific released version of repository.
  - For example, use `https://github.com/mapbox/maki/archive/refs/tags/v7.0.0.zip` instead of `https://github.com/mapbox/maki/zipball/main`.
- We may run some of tests periodically that confirm this repository working expectedly.
