### PR TITLE
Build tiles only when it doesn't exist yet

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -54,8 +54,10 @@ end
 
 desc 'build tiles from source data'
 task :tiles do
-  sh "osmium export --config osmium-export-config.json --index-type=sparse_file_array --output-format=geojsonseq --output=- src/#{AREA}-latest.osm.pbf | node filter.js | tippecanoe --no-feature-limit --no-tile-size-limit --force --simplification=2 --maximum-zoom=15 --base-zoom=15 --hilbert --output=#{MBTILES}"
-  sh "tile-join --force --no-tile-compression --output-to-directory=docs/zxy --no-tile-size-limit #{MBTILES}"
+  if !File.exist?("./src/tiles.mbtiles")
+    sh "osmium export --config osmium-export-config.json --index-type=sparse_file_array --output-format=geojsonseq --output=- src/#{AREA}-latest.osm.pbf | node filter.js | tippecanoe --no-feature-limit --no-tile-size-limit --force --simplification=2 --maximum-zoom=15 --base-zoom=15 --hilbert --output=#{MBTILES}"
+    sh "tile-join --force --no-tile-compression --output-to-directory=docs/zxy --no-tile-size-limit #{MBTILES}"
+  end
 end
 
 desc 'build style.json from HOCON descriptions'


### PR DESCRIPTION

`entrypoint.sh` always run `rake tiles` when `docker compose up`.
rake task `tiles` it very heavy process, so that has making it difficult to check overall operation by using docker compose.
So I suggest build tiles only when it doesn't exist yet.